### PR TITLE
fix: 修复hydorgen主题的一些问题，以及对一些文章的元素进行主题定制和更改

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ highlight: juejin
 | [smartblue](https://github.com/cumt-robin/juejin-markdown-theme-smart-blue) | [掘金](https://juejin.im/user/2752832847753085) [GitHub](https://github.com/cumt-robin) |
 | [cyanosis](https://github.com/linxsbox/juejin-markdown-theme-cyanosis) | [掘金](https://juejin.im/user/3175045313873943) [GitHub](https://github.com/linxsbox) |
 | [channing-cyan](https://github.com/ChanningHan/juejin-markdown-theme-channing-cyan) | [掘金](https://juejin.im/user/2101921963839678) [GitHub](https://github.com/ChanningHan) |
+| [DawnLck](https://github.com/DawnLck/juejin-markdown-theme-hydrogen) | [掘金](https://juejin.im/user/1028798614345032) [GitHub](https://github.com/DawnLck) |
 
 ### 代码高亮
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ highlight: juejin
 | [cyanosis](https://github.com/linxsbox/juejin-markdown-theme-cyanosis) | [掘金](https://juejin.im/user/3175045313873943) [GitHub](https://github.com/linxsbox) |
 | [channing-cyan](https://github.com/ChanningHan/juejin-markdown-theme-channing-cyan) | [掘金](https://juejin.im/user/2101921963839678) [GitHub](https://github.com/ChanningHan) |
 | [fancy](https://github.com/xrr2016/juejin-markdown-theme-fancy) | [掘金](https://juejin.im/user/835284564445415) [GitHub](https://github.com/xrr2016) |
-| [DawnLck](https://github.com/DawnLck/juejin-markdown-theme-hydrogen) | [掘金](https://juejin.im/user/1028798614345032) [GitHub](https://github.com/DawnLck) |
+| [hydrogen](https://github.com/DawnLck/juejin-markdown-theme-hydrogen) | [掘金](https://juejin.im/user/1028798614345032) [GitHub](https://github.com/DawnLck) |
 
 ### 代码高亮
 

--- a/themes.js
+++ b/themes.js
@@ -39,7 +39,7 @@ export default {
     owner: 'DawnLck',
     repo: 'juejin-markdown-theme-hydrogen',
     path: 'hydrogen.scss',
-    ref: '9352465',
+    ref: '0b9a5f1',
   },
   fancy: {
     owner: 'xrr2016',

--- a/themes.js
+++ b/themes.js
@@ -29,4 +29,10 @@ export default {
     path: 'channing-cyan.scss',
     ref: 'e8337e2',
   },
+  hydrogen: {
+    owner: 'DawnLck',
+    repo: 'juejin-markdown-theme-hydrogen',
+    path: 'hydrogen.scss',
+    ref: 'b6aed6a',
+  },
 };

--- a/themes.js
+++ b/themes.js
@@ -33,6 +33,6 @@ export default {
     owner: 'DawnLck',
     repo: 'juejin-markdown-theme-hydrogen',
     path: 'hydrogen.scss',
-    ref: 'b6aed6a',
+    ref: '77e6572',
   },
 };

--- a/themes.js
+++ b/themes.js
@@ -33,7 +33,7 @@ export default {
     owner: 'DawnLck',
     repo: 'juejin-markdown-theme-hydrogen',
     path: 'hydrogen.scss',
-    ref: '77e6572',
+    ref: '9352465',
   },
   fancy: {
     owner: 'xrr2016',


### PR DESCRIPTION
1. 在新的主题提交里，优化了blockquote、删除线、代码块、链接等呈现
2. 修复了在英文文章中，每一个单词都是首字母大写的BUG

附其他几张主题对比图
![image](https://user-images.githubusercontent.com/12195307/99150589-a3514f00-26d0-11eb-84a4-f5344babcf1c.png)
![image](https://user-images.githubusercontent.com/12195307/99150594-ab10f380-26d0-11eb-974f-dc91a45f07e8.png)
![image](https://user-images.githubusercontent.com/12195307/99150598-b06e3e00-26d0-11eb-8ca4-5c88e5709635.png)
