### PR TITLE
theme-> healer-readable

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,18 +25,19 @@ highlight: juejin # 代码高亮主题，默认值：theme 中指定
 
 #### 社区主题
 
-| 主题                                                                                | 作者                                                      | License |
-| ----------------------------------------------------------------------------------- | --------------------------------------------------------- | ------- |
-| [smartblue](https://github.com/cumt-robin/juejin-markdown-theme-smart-blue)         | [Tusi](https://juejin.im/user/2752832847753085)           | MIT     |
-| [cyanosis](https://github.com/linxsbox/juejin-markdown-theme-cyanosis)              | [林小帅](https://juejin.im/user/3175045313873943)         | MIT     |
-| [channing-cyan](https://github.com/ChanningHan/juejin-markdown-theme-channing-cyan) | [ChanningHyl🙌](https://juejin.im/user/2101921963839678)   | MIT     |
-| [fancy](https://github.com/xrr2016/juejin-markdown-theme-fancy)                     | [冷石 Boy](https://juejin.im/user/835284564445415)        | MIT     |
-| [hydrogen](https://github.com/DawnLck/juejin-markdown-theme-hydrogen)               | [DawnLck 在掘金](https://juejin.im/user/1028798614345032) | MIT     |
-| [condensed-night-purple](https://github.com/Geekhyt/condensed-night-purple)         | [童欧巴](https://juejin.im/user/3491704662669469)         | MIT     |
-| [greenwillow](https://github.com/wangly19/juejin-markdown-theme-greenwillow)        | [wangly19](https://juejin.im/user/4248168660735310)       | MIT     |
-| [v-green](https://github.com/DawnLck/juejin-markdown-theme-v-green)                 | [DawnLck 在掘金](https://juejin.im/user/1028798614345032) | MIT     |
-| [vue-pro](https://github.com/dunizb/juejin-markdown-themes)                         | [杭州程序员张张](https://juejin.cn/user/289926798645575)  | MIT     |
-| [healer-readable](https://github.com/dunizb/juejin-markdown-theme-healer-readable)  | [healer](https://juejin.cn/user/1415826709689208)         | MIT     |
+| 主题 | 作者 | License |
+| --- | --- | --- |
+| [smartblue](https://github.com/cumt-robin/juejin-markdown-theme-smart-blue) | [Tusi](https://juejin.im/user/2752832847753085) | MIT |
+| [cyanosis](https://github.com/linxsbox/juejin-markdown-theme-cyanosis) | [林小帅](https://juejin.im/user/3175045313873943) | MIT |
+| [channing-cyan](https://github.com/ChanningHan/juejin-markdown-theme-channing-cyan) | [ChanningHyl🙌](https://juejin.im/user/2101921963839678) | MIT |
+| [fancy](https://github.com/xrr2016/juejin-markdown-theme-fancy) | [冷石 Boy](https://juejin.im/user/835284564445415) | MIT |
+| [hydrogen](https://github.com/DawnLck/juejin-markdown-theme-hydrogen) | [DawnLck 在掘金](https://juejin.im/user/1028798614345032) | MIT |
+| [condensed-night-purple](https://github.com/Geekhyt/condensed-night-purple) | [童欧巴](https://juejin.im/user/3491704662669469) | MIT |
+| [greenwillow](https://github.com/wangly19/juejin-markdown-theme-greenwillow) | [wangly19](https://juejin.im/user/4248168660735310) | MIT |
+| [v-green](https://github.com/DawnLck/juejin-markdown-theme-v-green) | [DawnLck 在掘金](https://juejin.im/user/1028798614345032) | MIT |
+| [vue-pro](https://github.com/dunizb/juejin-markdown-themes) | [杭州程序员张张](https://juejin.cn/user/289926798645575) | MIT |
+| [healer-readable](https://github.com/dunizb/juejin-markdown-theme-healer-readable) | [healer](https://juejin.cn/user/1415826709689208) | MIT |
+
 
 ### 代码高亮
 

--- a/README.md
+++ b/README.md
@@ -25,17 +25,18 @@ highlight: juejin # 代码高亮主题，默认值：theme 中指定
 
 #### 社区主题
 
-| 主题 | 作者 | License |
-| --- | --- | --- |
-| [smartblue](https://github.com/cumt-robin/juejin-markdown-theme-smart-blue) | [Tusi](https://juejin.im/user/2752832847753085) | MIT |
-| [cyanosis](https://github.com/linxsbox/juejin-markdown-theme-cyanosis) | [林小帅](https://juejin.im/user/3175045313873943) | MIT |
-| [channing-cyan](https://github.com/ChanningHan/juejin-markdown-theme-channing-cyan) | [ChanningHyl🙌](https://juejin.im/user/2101921963839678) | MIT |
-| [fancy](https://github.com/xrr2016/juejin-markdown-theme-fancy) | [冷石 Boy](https://juejin.im/user/835284564445415) | MIT |
-| [hydrogen](https://github.com/DawnLck/juejin-markdown-theme-hydrogen) | [DawnLck 在掘金](https://juejin.im/user/1028798614345032) | MIT |
-| [condensed-night-purple](https://github.com/Geekhyt/condensed-night-purple) | [童欧巴](https://juejin.im/user/3491704662669469) | MIT |
-| [greenwillow](https://github.com/wangly19/juejin-markdown-theme-greenwillow) | [wangly19](https://juejin.im/user/4248168660735310) | MIT |
-| [v-green](https://github.com/DawnLck/juejin-markdown-theme-v-green) | [DawnLck 在掘金](https://juejin.im/user/1028798614345032) | MIT |
-| [vue-pro](https://github.com/dunizb/juejin-markdown-themes) | [杭州程序员张张](https://juejin.cn/user/289926798645575) | MIT |
+| 主题                                                                                | 作者                                                      | License |
+| ----------------------------------------------------------------------------------- | --------------------------------------------------------- | ------- |
+| [smartblue](https://github.com/cumt-robin/juejin-markdown-theme-smart-blue)         | [Tusi](https://juejin.im/user/2752832847753085)           | MIT     |
+| [cyanosis](https://github.com/linxsbox/juejin-markdown-theme-cyanosis)              | [林小帅](https://juejin.im/user/3175045313873943)         | MIT     |
+| [channing-cyan](https://github.com/ChanningHan/juejin-markdown-theme-channing-cyan) | [ChanningHyl🙌](https://juejin.im/user/2101921963839678)   | MIT     |
+| [fancy](https://github.com/xrr2016/juejin-markdown-theme-fancy)                     | [冷石 Boy](https://juejin.im/user/835284564445415)        | MIT     |
+| [hydrogen](https://github.com/DawnLck/juejin-markdown-theme-hydrogen)               | [DawnLck 在掘金](https://juejin.im/user/1028798614345032) | MIT     |
+| [condensed-night-purple](https://github.com/Geekhyt/condensed-night-purple)         | [童欧巴](https://juejin.im/user/3491704662669469)         | MIT     |
+| [greenwillow](https://github.com/wangly19/juejin-markdown-theme-greenwillow)        | [wangly19](https://juejin.im/user/4248168660735310)       | MIT     |
+| [v-green](https://github.com/DawnLck/juejin-markdown-theme-v-green)                 | [DawnLck 在掘金](https://juejin.im/user/1028798614345032) | MIT     |
+| [vue-pro](https://github.com/dunizb/juejin-markdown-themes)                         | [杭州程序员张张](https://juejin.cn/user/289926798645575)  | MIT     |
+| [healer-readable](https://github.com/dunizb/juejin-markdown-theme-healer-readable)  | [healer](https://juejin.cn/user/1415826709689208)         | MIT     |
 
 ### 代码高亮
 

--- a/themes.js
+++ b/themes.js
@@ -73,6 +73,6 @@ export default {
     repo: 'juejin-markdown-theme-healer-readable',
     path: 'healer-readable.scss',
     ref: 'c35582e',
-    highlight: 'vs2015'
+    highlight: 'srcery'
   }
 };

--- a/themes.js
+++ b/themes.js
@@ -72,7 +72,7 @@ export default {
     owner: 'healerLZH',
     repo: 'juejin-markdown-theme-healer-readable',
     path: 'healer-readable.scss',
-    ref: 'c35582e',
+    ref: '3f2ef56',
     highlight: 'srcery'
   }
 };

--- a/themes.js
+++ b/themes.js
@@ -67,5 +67,12 @@ export default {
     path: 'vue-pro.scss',
     ref: '836e9bc',
     highlight: 'juejin'
+  },
+  'healer-readable': {
+    owner: 'healerLZH',
+    repo: 'juejin-markdown-theme-healer-readable',
+    path: 'healer-readable.scss',
+    ref: 'c35582e',
+    highlight: 'vs2015'
   }
 };


### PR DESCRIPTION
### 主题名称：healer-readable
### highlight：srcery
### 主题色：#007fff  【取自掘金Logo】

文章多以文字、代码为主，我目前体验上有的主题字体很小，不方便阅读。针对代码块内字体过小影响预读的问题做了修改，整体基础字号18，字间距1，相对宽松，不显得过于紧密，减少字体小让瞳孔过于专注的疲乏。
