### PR TITLE
fix: awesome-green style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 gallery/themes.js
 .idea/
+yarn.lock

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ highlight: juejin # 代码高亮主题，默认值：theme 中指定，没有则
 | [mk-cute](https://github.com/Jacky-Summer/juejin-markdown-theme-mk-cute) | [JackySummer](https://juejin.cn/user/1257497033714477) | MIT |
 | [jzman](https://github.com/jzmanu/juejin-markdown-theme-jzman) | [躬行之](https://juejin.cn/user/3526889030301325) | MIT |
 | [geek-black](https://github.com/MageeLin/juejin-markdown-theme-geek-black) | [林景宜](https://juejin.cn/user/404232342875966) | MIT |
-| [awesome-green](https://github.com/luffyZh/juejin-markdown-theme-awesome-green) | [luffyZh](https://juejin.cn/user/404232342875966) | MIT |
+| [awesome-green](https://github.com/luffyZh/juejin-markdown-theme-awesome-green) | [luffyZh](https://juejin.cn/user/96412752681079) | MIT |
 
 ### 代码高亮
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ highlight: juejin # 代码高亮主题，默认值：theme 中指定，没有则
 | [mk-cute](https://github.com/Jacky-Summer/juejin-markdown-theme-mk-cute) | [JackySummer](https://juejin.cn/user/1257497033714477) | MIT |
 | [jzman](https://github.com/jzmanu/juejin-markdown-theme-jzman) | [躬行之](https://juejin.cn/user/3526889030301325) | MIT |
 | [geek-black](https://github.com/MageeLin/juejin-markdown-theme-geek-black) | [林景宜](https://juejin.cn/user/404232342875966) | MIT |
+| [awesome-green](https://github.com/luffyZh/juejin-markdown-theme-awesome-green) | [luffyZh](https://juejin.cn/user/404232342875966) | MIT |
 
 ### 代码高亮
 

--- a/themes.js
+++ b/themes.js
@@ -100,6 +100,6 @@ export default {
     owner: 'luffyZh',
     repo: 'juejin-markdown-theme-awesome-green',
     path: 'awesome-green.scss',
-    ref: '0d1a43a',
+    ref: '5e8259b',
   },
 };

--- a/themes.js
+++ b/themes.js
@@ -96,4 +96,10 @@ export default {
     ref: '7601c42',
     highlight: 'monokai',
   },
+  'awesome-green': {
+    owner: 'luffyZh',
+    repo: 'juejin-markdown-theme-awesome-green',
+    path: 'awesome-green.scss',
+    ref: '0d1a43a',
+  },
 };


### PR DESCRIPTION
非常感谢昨天很快的通过了PR，不过今天在试用的时候发现了几个样式bug，再提一个修复版：

 - 问题一：table样式没有撑满，导致标题和表格布局错乱(非必现，偶尔能刷出来，直接改了)
 - 问题二： a 标签的 [class^="footnote"] 样式太过于紧凑，单独进行了处理
 - 问题三：社区作者的链接填写错了
 
原本的问题截图：
<img width="896" alt="图片" src="https://user-images.githubusercontent.com/17840558/102957734-278bc300-4516-11eb-95bb-239cb03934d7.png">

解决后的截图：

<img width="942" alt="图片" src="https://user-images.githubusercontent.com/17840558/102958246-725a0a80-4517-11eb-97ff-12cd0ef5cdc0.png">
