### PR TITLE
feat: 新增DEVUI蓝掘金主题

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ highlight: juejin # 代码高亮主题，默认值：theme 中指定，没有则
 | [arknights](https://github.com/viewweiwu/juejin-markdown-theme-arknights) | [viewweiwu](https://juejin.cn/user/712139263452503) | MIT |
 | [vuepress](https://github.com/promise96319/juejin-markdown-theme-vuepress) | [qgh](https://juejin.cn/user/3685218708627544) | MIT |
 | [Chinese-red](https://github.com/mancuoj/juejin-markdown-theme-Chinese-red) | [Mancuoj](https://juejin.cn/user/3466105460624760) | MIT |
+| [devui-blue](https://github.com/kagol/juejin-markdown-theme-devui-blue) | [DevUI团队](https://juejin.cn/user/712139267650141) | MIT |
 
 ### 代码高亮
 

--- a/themes.js
+++ b/themes.js
@@ -153,7 +153,13 @@ const themes = {
     path: 'Chinese-red.scss',
     ref: 'ac8c9e5',
     highlight: 'xcode',
-  }
+  },
+  'devui-blue': {
+    owner: 'kagol',
+    repo: 'juejin-markdown-theme-devui-blue',
+    path: 'devui-blue.scss',
+    ref: '127cfeb',
+  },
 };
 
 export default themes;


### PR DESCRIPTION
`DEVUI蓝`掘金主题以代表成熟、专业的靛蓝`#5E7CE0`为主色，以珊瑚红`#C73636`为点缀色，通过`DevUI Design`的色彩体系进行色阶的扩展，形成`DEVUI蓝`的掘金主题。

## 引用

![image](https://user-images.githubusercontent.com/9566362/152367343-34fcb990-c1c6-4893-8c6d-4d4248266bd5.png)

## 标题 h1-h6

![image](https://user-images.githubusercontent.com/9566362/152368984-75770716-8960-47f0-90a8-90a28e18f3f8.png)

## 列表

![image](https://user-images.githubusercontent.com/9566362/152370083-cf613a3e-1e5a-46aa-9e10-fa820bff1c23.png)

![image](https://user-images.githubusercontent.com/9566362/152371415-8558f49b-48bf-4dc3-a6e7-90272ed140d8.png)

## 链接

![image](https://user-images.githubusercontent.com/9566362/152370167-76104e47-bc44-436d-9738-a9ec43d83bb8.png)

## 表格

![image](https://user-images.githubusercontent.com/9566362/152369215-441c8f21-413e-40f4-a378-6120e3c059f3.png)

## 任务列表

![image](https://user-images.githubusercontent.com/9566362/152369407-188ff94d-c728-41c7-b371-7cd9dbf33ea4.png)
