### PR TITLE
feat: 增加themes.js格式错误的提示信息

### DIFF
--- a/build.js
+++ b/build.js
@@ -40,7 +40,14 @@ const handlerMap = {
 
     const code = await fetch(
       `https://raw.githubusercontent.com/${p.owner}/${p.repo}/${p.ref}/${p.path}`
-    ).then((res) => res.text());
+    ).then((res) => res.text())
+    .catch(() => {
+      throw new Error(
+        'Oops! themes.js format is wrong, ' +
+        'please refer to this link for corrections: ' +
+        'https://github.com/xitu/juejin-markdown-themes#-themesjs-%E6%A0%BC%E5%BC%8F%E8%AF%B4%E6%98%8E.'
+      );
+    });
 
     const ext = path.extname(p.path).slice(1);
     const css = await handlerMap[ext](code);


### PR DESCRIPTION
`themes.js`中的格式填写错误，比如`owner`拼写错误，会直接导致`build`失败，但是提示信息并不友好，这个PR就是为这种`themes.js`格式错误导致的构建失败增加更友好的提示信息。

提示信息如下：

Oops! themes.js format is wrong, please refer to this link for corrections: https://github.com/xitu/juejin-markdown-themes#-themesjs-%E6%A0%BC%E5%BC%8F%E8%AF%B4%E6%98%8E.
