### PR TITLE
fix(devui-blue): 解决DEVUI蓝主题文件尺寸过大问题

### DIFF
--- a/themes.js
+++ b/themes.js
@@ -165,7 +165,7 @@ const themes = {
     owner: 'kagol',
     repo: 'juejin-markdown-theme-devui-blue',
     path: 'devui-blue.scss',
-    ref: '127cfeb',
+    ref: '2caac0c',
   },
 };
 


### PR DESCRIPTION
删除了尺寸过大的base64图片，目前主题文件尺寸已降到`20KB`以下。