### PR TITLE
更新样式变量和默认的代码块高亮样式

### DIFF
--- a/themes.js
+++ b/themes.js
@@ -144,8 +144,8 @@ const themes = {
     owner: 'promise96319',
     repo: 'juejin-markdown-theme-vuepress',
     path: 'vuepress.scss',
-    ref: 'af6f62a',
-    highlight: 'base16/tomorrow-night',
+    ref: 'cc771b5',
+    highlight: 'atom-one-dark',
   },
   'Chinese-red': {
     owner: 'Mancuoj',


### PR DESCRIPTION
1.移除 h1-h6 标签中的 # 号，解决标题中莫名出现 # 号的问题。
2.提取 scss 公用变量，便于后续维护;
3.对间距进行微调，影响范围较小，不影响用户正常使用;
4.增加本地主题开发环境，便于后续维护;
5.将代码块高亮改为 atom-one-dark，解决之前设置的值不生效的问题。