### PR TITLE
fix: 优化 awesome-green 部分样式

### DIFF
--- a/themes.js
+++ b/themes.js
@@ -106,7 +106,7 @@ const themes = {
     owner: 'luffyZh',
     repo: 'juejin-markdown-theme-awesome-green',
     path: 'awesome-green.scss',
-    ref: 'fc93130',
+    ref: 'f8ec354',
   },
   'qklhk-chocolate': {
     owner: 'QiaokeliHenku',


### PR DESCRIPTION
 - 优化表格样式
 - 优化提示类型代码块样式
 - 优化单行代码样式

====================================

主题进行了相关优化如下：

 - Table 样式优化，见讨论：https://juejin.cn/pin/7112000334360215582
 - success、error、warning、info 四种提示类型兼容适配

这四种类型在开发模式下没问题，但是文章实际发布的时候会出现如下状况：

<img width="868" alt="image" src="https://user-images.githubusercontent.com/17840558/176813625-122d4f34-4aed-469e-9017-1a3fc8a6ce6c.png">

修复后：
<img width="812" alt="image" src="https://user-images.githubusercontent.com/17840558/176813821-878a17ec-1b2d-4101-8486-737ab48554b5.png">
- 优化单行 code 样式，适配绿色主题
- 优化多行 code 样式，语言被遮盖的问题
