### PR TITLE
fix: 修复 devui-blue 主题超链接图标偏移问题

### DIFF
--- a/themes.js
+++ b/themes.js
@@ -165,7 +165,7 @@ const themes = {
     owner: 'kagol',
     repo: 'juejin-markdown-theme-devui-blue',
     path: 'devui-blue.scss',
-    ref: '2caac0c',
+    ref: 'bb59b1b',
   },
 };
 


### PR DESCRIPTION
badcase: https://juejin.cn/post/7206909221806981175/