### PR TITLE
feat: 新增主题 liting

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,9 @@ highlight: juejin # 代码高亮主题，默认值：theme 中指定，没有则
 | [vuepress](https://github.com/promise96319/juejin-markdown-theme-vuepress) | [qgh](https://juejin.cn/user/3685218708627544) | MIT |
 | [Chinese-red](https://github.com/mancuoj/juejin-markdown-theme-Chinese-red) | [Mancuoj](https://juejin.cn/user/3466105460624760) | MIT |
 | [nico](https://github.com/blllld/juejin-markdown-theme-nico) | [非思不可](https://juejin.cn/user/553809588523405) | MIT |
-| [devui-blue](https://github.com/kagol/juejin-markdown-theme-devui-blue) | [DevUI团队](https://juejin.cn/user/712139267650141) | MIT |
+| [devui-blue](https://github.com/kagol/juejin-markdown-theme-devui-blue) | [DevUI 团队](https://juejin.cn/user/712139267650141) | MIT |
 | [qklhk-chocolate](https://github.com/qklhk/juejin-markdown-theme-qklhk/) | [巧克力很苦](https://juejin.cn/user/1011206429358087) | Apache |
+| [liting](https://github.com/liting-yes/juejin-markdown-theme-liting) | [文侯](https://juejin.cn/user/2217072231984919) | MIT |
 
 ### 代码高亮
 
@@ -74,7 +75,6 @@ highlight: juejin # 代码高亮主题，默认值：theme 中指定，没有则
 9. 注意考虑样式的稳定性和兼容性
 10. **并非所有 PR 的主题都会入选，挑选和审核会有一定周期**
 
-
 ### ① themes.js 格式说明
 
 ```js
@@ -90,9 +90,9 @@ highlight: juejin # 代码高亮主题，默认值：theme 中指定，没有则
 ## License
 
 ## 联系官方
+
 微信：zwcatfly 或者微信： chnyifan
 
 ![middle_img_v2_76ee7552-1a63-41df-900d-5fbefe5a69ag](https://user-images.githubusercontent.com/8282645/139875601-f0f3477d-a03a-4acf-ac8d-7204d4f5bc04.jpg)
-
 
 MIT

--- a/themes.js
+++ b/themes.js
@@ -171,7 +171,7 @@ const themes = {
     owner: 'liting-yes',
     repo: 'juejin-markdown-theme-liting',
     path: 'liting.scss',
-    ref: '9ac543f',
+    ref: '21ec63e',
     highlight: 'kimbie-light'
   }
 };

--- a/themes.js
+++ b/themes.js
@@ -154,12 +154,12 @@ const themes = {
     ref: '6da886e',
     highlight: 'xcode',
   },
-  'nico':{
-    owner:"blllld",
-    repo:"juejin-markdown-theme-nico",
-    path:"nico.scss",
-    ref:'8177657',
-    highlight:'atelier-sulphurpool-light'
+  'nico': {
+    owner: "blllld",
+    repo: "juejin-markdown-theme-nico",
+    path: "nico.scss",
+    ref: '8177657',
+    highlight: 'atelier-sulphurpool-light'
   },
   'devui-blue': {
     owner: 'kagol',
@@ -167,6 +167,13 @@ const themes = {
     path: 'devui-blue.scss',
     ref: 'bb59b1b',
   },
+  'liting': {
+    owner: 'liting-yes',
+    repo: 'juejin-markdown-theme-liting',
+    path: 'liting.scss',
+    ref: '9ac543f',
+    highlight: 'kimbie-light'
+  }
 };
 
 export default themes;


### PR DESCRIPTION
> 本人 UI 设计修炼还不到家，欢迎提供样式意见

- 支持深色模式
- 主题色为 [tailwindcss](https://tailwindcss.com/) 的 **Slate** 色系，副色采用 **Amber** 色系
- 字体采用 [霞鹜文楷屏幕阅读版](https://github.com/lxgw/LxgwWenKai-Screen.git)
- p 元素内容 hover 时字体颜色加深
- a 元素设置 hover 时下划线颜色过渡
- pre 元素 hover 时有加深阴影