### PR TITLE
feat: add theme minimalism

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ highlight: juejin # 代码高亮主题，默认值：theme 中指定，没有则
 | [qklhk-chocolate](https://github.com/qklhk/juejin-markdown-theme-qklhk/) | [巧克力很苦](https://juejin.cn/user/1011206429358087) | Apache |
 | [serene-rose](https://github.com/Krue1/juejin-markdown-theme-serene-rose) | [Krue](https://juejin.cn/user/1143110510329256) | MIT |
 | [z-blue](https://github.com/sheng1998/juejin-markdown-theme-z-blue) | [z_](https://juejin.cn/user/4212984289441422) | MIT |
+| [minimalism](https://github.com/justnewbee/juejin-markdown-theme-minimalism) | [驳是](https://juejin.cn/user/442445375748621) | MIT |
 
 ### 代码高亮
 

--- a/themes.js
+++ b/themes.js
@@ -185,7 +185,7 @@ const themes = {
     owner: 'justnewbee',
     repo: 'juejin-markdown-theme-minimalism',
     path: 'minimalism.scss',
-    ref: '78d682e',
+    ref: 'cc3853c',
     highlight: 'atom-one-dark',
   },
 };

--- a/themes.js
+++ b/themes.js
@@ -181,6 +181,13 @@ const themes = {
     ref: '9057224',
     highlight: 'androidstudio',
   },
+  'minimalism': {
+    owner: 'justnewbee',
+    repo: 'juejin-markdown-theme-minimalism',
+    path: 'minimalism.scss',
+    ref: '78d682e',
+    highlight: 'atom-one-dark',
+  },
 };
 
 export default themes;

--- a/themes.js
+++ b/themes.js
@@ -185,7 +185,7 @@ const themes = {
     owner: 'justnewbee',
     repo: 'juejin-markdown-theme-minimalism',
     path: 'minimalism.scss',
-    ref: 'cc3853c',
+    ref: '246f4f0',
     highlight: 'atom-one-dark',
   },
 };


### PR DESCRIPTION
主题特点：

1. 支持暗黑模式
2. 字体粗细温和，默认 200，粗体用 400，没有 600
3. 行距、段落间距适中
4. 表格的展示能适应 90% 的展示场景（`th` 不折行、`td` 最小 72px 宽度），不至于有些内容被压缩得特别难看
5. `em` 元素为橙色
6. 支持 `kbd`