### PR TITLE
fix: minimalism theme code block line-number will break

### DIFF
--- a/themes.js
+++ b/themes.js
@@ -185,7 +185,7 @@ const themes = {
     owner: 'justnewbee',
     repo: 'juejin-markdown-theme-minimalism',
     path: 'minimalism.scss',
-    ref: '246f4f0',
+    ref: 'f7c4a7b',
     highlight: 'atom-one-dark',
   },
   'koi': {


### PR DESCRIPTION
.code-block-extension-codeLine::before 的样式 `width: 18px` 在 pre 的 `white-space: pre-wrap` 下会折行，目前的解法是在主题中把 pre 下的样式改成 `white-space: pre`，但最佳的解法实际上是掘金这边改，把 `width` 改成 `min-width`

<img width="1799" alt="image" src="https://github.com/user-attachments/assets/da2258c0-2286-4884-a032-58d17d4c4f70" />
