### PR TITLE
feat: add ink-mist theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ highlight: juejin # 代码高亮主题，默认值：theme 中指定，没有则
 | [yu](https://github.com/jianghurong/juejin-markdown-theme-yu) | [荣易](https://juejin.cn/user/2400989124501549) | MIT |
 | [lilsnake](https://github.com/SnakeLil/juejin-markdown-theme-lilsnake) | [小蛇](https://juejin.cn/user/187347597270411) | MIT |
 | [keepnice](https://github.com/yangbo5207/juejin-markdown-theme-keepNice) | [这波能反杀](https://juejin.cn/user/2541726582702238) | MIT |
+| [ink-mist](https://github.com/chnjames/juejin-markdown-theme-ink-mist) | [一点一木](https://juejin.cn/user/1063982986187486) | MIT |
 
 
 ### 代码高亮

--- a/themes.js
+++ b/themes.js
@@ -216,6 +216,13 @@ const themes = {
     ref: '38645c3',
     highlight: 'github',
   },
+  'ink-mist': {
+    owner: 'chnjames',
+    repo: 'juejin-markdown-theme-ink-mist',
+    path: 'ink-mist.scss',
+    ref: '3544ef8',
+    highlight: 'atom-one-dark',
+  },
 };
 
 export default themes;


### PR DESCRIPTION
## 摘要

新增社区 Markdown 主题 **ink-mist**。

## 变更说明

- 在 `themes.js` 中注册主题 `ink-mist`，指向仓库 [chnjames/juejin-markdown-theme-ink-mist](https://github.com/chnjames/juejin-markdown-theme-ink-mist)，样式文件 `ink-mist.scss`，`ref` 为固定 commit，`highlight` 默认为 `atom-one-dark`。
- 在 `README.md` 的「社区主题」表格中补充对应一行（主题、作者、License）。

## 自检

- [x] 已基于 `upstream/main` 做 rebase，提交记录整洁（单条 `feat:` commit）
- [x] `themes.js` 与 README 中的作者、仓库链接、掘金主页一致